### PR TITLE
Fix the CORS issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "index.js",
   "scripts": {
     "test": "tape tests/*.js | faucet",
+    "serve": "browser-sync start -s --https --ss public -f 'public/*'",
     "start": "nodemon src/server.js"
   },
   "repository": {

--- a/src/handleAPI.js
+++ b/src/handleAPI.js
@@ -1,5 +1,5 @@
 function handleAPI(response, api) {
-  response.writeHead(200, { 'content-type': 'application/json' });
+  response.writeHead(200, { 'content-type': 'application/json', 'application-control-origin': '*' });
   response.end(JSON.stringify(api));
 }
 


### PR DESCRIPTION
Adds the correct `access-control-origin` header 
Also adds a `npm run serve` command that creates a local https server to avoid mixed content errors
Closes #29