### PR TITLE
Use the correct header stupid

### DIFF
--- a/src/handleAPI.js
+++ b/src/handleAPI.js
@@ -1,5 +1,5 @@
 function handleAPI(response, api) {
-  response.writeHead(200, { 'content-type': 'application/json', 'application-control-origin': '*' });
+  response.writeHead(200, { 'content-type': 'application/json', 'access-control-allow-origin': '*' });
   response.end(JSON.stringify(api));
 }
 


### PR DESCRIPTION
I used the wrong header to set access-control-origin. Hopefully it works now
Relates #29 