### PR TITLE
Fixed handleAPI call

### DIFF
--- a/src/router.js
+++ b/src/router.js
@@ -21,7 +21,7 @@ module.exports = function (request, response) {
   } else if (extension === 'css' || extension === 'js' || extension === 'html' || extension === 'ico') {
     handlers.servePublic(request, response);
   } else if (url.indexOf('/api/words') !== -1) {
-    const splitUrl = url.replace('/api/words/?', '').split('&');
+    const splitUrl = url.replace('/api/words?', '').split('&');
 
     const dataHolder = {};
 
@@ -42,7 +42,7 @@ module.exports = function (request, response) {
     APIResponse.id = dataHolder.id;
     APIResponse.words = letterArr.slice(0, 10);
 
-    handlers.handleAPI(response, letterArr);
+    handlers.handleAPI(response, APIResponse);
   } else {
     handlers.pageNotFound(request, response);
   }


### PR DESCRIPTION
We made a mistake in our last PR, we passed the wrong argument to our handleAPI function on line 45 of src/handlers.js. We passed the entire array of letters rather than the APIResponse object we had constructed. Oops. :flushed: 
Relates to #21 