### PR TITLE
add 3 tests and improve regex

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "test": "tape tests/*.js | faucet",
+    "test": "tape tests/handleAPI.test.js | faucet",
     "serve": "browser-sync start -s --https --ss public -f 'public/*'",
     "start": "nodemon src/server.js"
   },

--- a/src/handleAPI.js
+++ b/src/handleAPI.js
@@ -21,7 +21,7 @@ function handleAPI(url) {
     dataHolder[keyValue[0]] = keyValue[1];
   });
 
-  dataHolder.query = dataHolder.query.replace(/[^A-z]/gi, '');
+  dataHolder.query = dataHolder.query.replace(/[^A-z]|\[|\]/gi, '');
 
   if (dataHolder.query.length === 0) {
     return {

--- a/tests/handleAPI.test.js
+++ b/tests/handleAPI.test.js
@@ -16,7 +16,6 @@ const jsonHolder = {
 
 
 test('handleAPI control test', (t) => {
-  t.plan(1);
   const query = 'a';
   const url = `/api/words?type=noun&id=0&query=${query}`;
   const expected = {
@@ -25,10 +24,10 @@ test('handleAPI control test', (t) => {
   };
   const actual = handleAPI(url);
   t.deepEqual(expected, actual, 'return value of handleAPI should be same as expected when passed a valid input');
+  t.end();
 });
 
-test('handleAPI test', (t) => {
-  t.plan(1);
+test('handleAPI test with single number', (t) => {
   const query = '0';
   const url = `/api/words?type=noun&id=0&query=${query}`;
   const expected = {
@@ -37,4 +36,41 @@ test('handleAPI test', (t) => {
   };
   const actual = handleAPI(url);
   t.deepEqual(expected, actual, 'return value of handleAPI should be a warning if given invalid input');
+  t.end();
+});
+
+test('handleAPI test with single dash', (t) => {
+  const query = '-';
+  const url = `/api/words?type=noun&id=0&query=${query}`;
+  const expected = {
+    id: '0',
+    words: ['Please only enter alphabetical characters'],
+  };
+  const actual = handleAPI(url);
+  t.deepEqual(expected, actual, 'return value of handleAPI should be a warning if given invalid input');
+  t.end();
+});
+
+test('handleAPI test with string of invalid characters', (t) => {
+  const query = '12345-+={}()';
+  const url = `/api/words?type=noun&id=0&query=${query}`;
+  const expected = {
+    id: '0',
+    words: ['Please only enter alphabetical characters'],
+  };
+  const actual = handleAPI(url);
+  t.deepEqual(expected, actual, 'return value of handleAPI should be a warning if given invalid input');
+  t.end();
+});
+
+test('handleAPI test with string with square brackets', (t) => {
+  const query = '[';
+  const url = `/api/words?type=noun&id=0&query=${query}`;
+  const expected = {
+    id: '0',
+    words: ['Please only enter alphabetical characters'],
+  };
+  const actual = handleAPI(url);
+  t.deepEqual(expected, actual, 'return value of handleAPI should be a warning if given invalid input');
+  t.end();
 });


### PR DESCRIPTION
We have added 3 new tests, each for non alphanumberic characters, the first takes a sigle dash, the second a string of numbers, dashes and brackets, and the third takes a single square bracket. We had to update our regex in our handleAPI function in order to account for the fact that square brackets are a special character in regex and need to be escaped. (thanks finn).
relates to #47