### PR TITLE
Fix file paths in handler.js

### DIFF
--- a/src/handlers/handleAPI.js
+++ b/src/handlers/handleAPI.js
@@ -21,7 +21,7 @@ function handleAPI(url) {
     dataHolder[keyValue[0]] = keyValue[1];
   });
 
-  dataHolder.query = dataHolder.query.replace(/[^A-z]|\[|\]/gi, '');
+  dataHolder.query = dataHolder.query.replace(/[^a-z]/gi, '');
 
   if (dataHolder.query.length === 0) {
     return {

--- a/src/handlers/handler.js
+++ b/src/handlers/handler.js
@@ -4,7 +4,7 @@ const path = require('path');
 const handlers = module.exports = {};
 
 handlers.serveLanding = function (request, response) {
-  fs.readFile(path.join(__dirname, '..', 'public', 'index.html'), (err, file) => {
+  fs.readFile(path.join(__dirname, '..', '..', 'public', 'index.html'), (err, file) => {
     if (err) return err;
     response.writeHead(200, 'Content-Type: text/html');
     response.end(file);
@@ -12,7 +12,7 @@ handlers.serveLanding = function (request, response) {
 };
 
 handlers.servePublic = function (request, response) {
-  fs.readFile(path.join(__dirname, '..', 'public', request.url), (err, file) => {
+  fs.readFile(path.join(__dirname, '..', '..', 'public', request.url), (err, file) => {
     if (err) return err;
     const extension = request.url.split('.')[1];
     const extensionType = {

--- a/src/routers/router.js
+++ b/src/routers/router.js
@@ -1,4 +1,4 @@
-const handlers = require('../handlers/handler');
+const handlers = require('../handlers/handler.js');
 const handleAPI = require('../handlers/handleAPI.js');
 
 module.exports = function (request, response) {

--- a/src/server.js
+++ b/src/server.js
@@ -1,5 +1,5 @@
 const http = require('http');
-const router = require('./router.js');
+const router = require('./routers/router.js');
 
 const host = process.env.HOST || 'localhost';
 const port = process.env.PORT || 4000;


### PR DESCRIPTION
When moving files around we neglected to go up another directory after nesting the handler.js file another directory deep, thus our serveLanding and servePublic functions did not work. This commit fixes this.
fixes #71 

Also fixed the regex (changed uppercase A to lowercase a). 
fixes #61 