### PR TITLE
Fixed merge conflicts and got error responses working

### DIFF
--- a/src/handlers/handler.js
+++ b/src/handlers/handler.js
@@ -5,7 +5,11 @@ const handlers = module.exports = {};
 
 handlers.serveLanding = function (request, response) {
   fs.readFile(path.join(__dirname, '..', '..', 'public', 'index.html'), (err, file) => {
-    if (err) return err;
+    if (err) {
+      response.writeHead(500, { 'Content-Type': 'text/html' });
+      response.write(`<h1>500 Server Error:</h1><h2>${err}</h2>`);
+      response.end();
+    }
     response.writeHead(200, 'Content-Type: text/html');
     response.end(file);
   });
@@ -13,7 +17,11 @@ handlers.serveLanding = function (request, response) {
 
 handlers.servePublic = function (request, response) {
   fs.readFile(path.join(__dirname, '..', '..', 'public', request.url), (err, file) => {
-    if (err) return err;
+    if (err) {
+      response.writeHead(500, { 'Content-Type': 'text/html' });
+      response.write(`<h1>500 Server Error:</h1><h2>${err}</h2>`);
+      response.end();
+    }
     const extension = request.url.split('.')[1];
     const extensionType = {
       html: 'text/html',


### PR DESCRIPTION
We weren't sending a response when there was an error finding a file. This lead to the browser endlessly loading. We now correctly respond with a 500 Error
Relates #58 